### PR TITLE
Email now supports both HTML and text bodies.

### DIFF
--- a/AccidentalFish.ApplicationSupport.Core/Alerts/Implementation/AlertSender.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Alerts/Implementation/AlertSender.cs
@@ -53,7 +53,7 @@ namespace AccidentalFish.ApplicationSupport.Core.Alerts.Implementation
             List<string> emailAddresses = subscribers.Select(x => x.Email).ToList();
             try
             {
-                _emailProvider.Send(emailAddresses, null, _sourceEmailAddress, title, message);
+                _emailProvider.Send(emailAddresses, null, _sourceEmailAddress, title, message, null);
             }
             catch (Exception)
             {

--- a/AccidentalFish.ApplicationSupport.Core/Email/EmailQueueItem.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/EmailQueueItem.cs
@@ -20,6 +20,8 @@ namespace AccidentalFish.ApplicationSupport.Core.Email
 
         public string Subject { get; set; }
 
-        public string Body { get; set; }
+        public string HtmlBody { get; set; }
+
+        public string TextBody { get; set; }
     }
 }

--- a/AccidentalFish.ApplicationSupport.Core/Email/IEmailManager.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/IEmailManager.cs
@@ -9,8 +9,8 @@ namespace AccidentalFish.ApplicationSupport.Core.Email
 
         Task Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string emailTemplateId, Dictionary<string, string> mergeValues);
 
-        Task Send(string to, string cc, string from, string subject, string body);
+        Task Send(string to, string cc, string from, string subject, string htmlBody, string textBody);
 
-        Task Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string subject, string body);
+        Task Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string subject, string htmlBody, string textBody);
     }
 }

--- a/AccidentalFish.ApplicationSupport.Core/Email/IEmailProvider.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/IEmailProvider.cs
@@ -4,6 +4,6 @@ namespace AccidentalFish.ApplicationSupport.Core.Email
 {
     public interface IEmailProvider
     {
-        string Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string title, string body);
+        string Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string title, string htmlBody, string textBody);
     }
 }

--- a/AccidentalFish.ApplicationSupport.Core/Email/Implementation/EmailManager.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/Implementation/EmailManager.cs
@@ -38,12 +38,12 @@ namespace AccidentalFish.ApplicationSupport.Core.Email.Implementation
             await _queue.EnqueueAsync(item);
         }
 
-        public Task Send(string to, string cc, string @from, string subject, string body)
+        public Task Send(string to, string cc, string @from, string subject, string htmlBody, string textBody)
         {
-            return Send(new[] { to }, new[] { cc }, @from, subject, body);
+            return Send(new[] { to }, new[] { cc }, @from, subject, htmlBody, textBody);
         }
 
-        public async Task Send(IEnumerable<string> to, IEnumerable<string> cc, string @from, string subject, string body)
+        public async Task Send(IEnumerable<string> to, IEnumerable<string> cc, string @from, string subject, string htmlBody, string textBody)
         {
             EmailQueueItem item = new EmailQueueItem
             {
@@ -51,7 +51,8 @@ namespace AccidentalFish.ApplicationSupport.Core.Email.Implementation
                 From = from,
                 To = new List<string>(to),
                 Subject = subject,
-                Body = body
+                HtmlBody = htmlBody,
+                TextBody = textBody
             };
 
             await _queue.EnqueueAsync(item);

--- a/AccidentalFish.ApplicationSupport.Core/Email/Providers/AmazonSimpleEmailProvider.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/Providers/AmazonSimpleEmailProvider.cs
@@ -24,13 +24,17 @@ namespace AccidentalFish.ApplicationSupport.Core.Email.Providers
             _secretKey = configuration["amazon-secret-key"];
         }
 
-        public string Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string title, string body)
+        public string Send(IEnumerable<string> to, IEnumerable<string> cc, string from, string title, string htmlBody, string textBody)
         {
             AmazonSimpleEmailServiceClient client = new AmazonSimpleEmailServiceClient(_accessKey, _secretKey);
             Destination destination = new Destination();
             destination.ToAddresses = to.ToList();
             Content subject = new Content(title);
-            Body bodyContent = new Body(new Content(body));
+            Body bodyContent = new Body()
+            {
+                Html = htmlBody == null ? null : new Content(htmlBody),
+                Text = textBody == null ? null : new Content(textBody)
+            };
             Message message = new Message(subject, bodyContent);
             SendEmailRequest request = new SendEmailRequest
             {

--- a/AccidentalFish.ApplicationSupport.Core/Email/Providers/SendGridEmailProvider.cs
+++ b/AccidentalFish.ApplicationSupport.Core/Email/Providers/SendGridEmailProvider.cs
@@ -22,7 +22,7 @@ namespace AccidentalFish.ApplicationSupport.Core.Email.Providers
             _sendgridPassword = applicationResourceFactory.Setting(ComponentIdentity, "password");
         }
 
-        public string Send(IEnumerable<string> to, IEnumerable<string> cc, string @from, string title, string body)
+        public string Send(IEnumerable<string> to, IEnumerable<string> cc, string @from, string title, string htmlBody, string textBody)
         {
             /*Mail mail = Mail.GetInstance();
             if (to != null && to.Any())
@@ -51,7 +51,10 @@ namespace AccidentalFish.ApplicationSupport.Core.Email.Providers
             {
                 message.AddTo(cc);
             }
-            message.Html = body;
+            if (htmlBody != null)
+                message.Html = htmlBody;
+            if (textBody != null)
+                message.Text = textBody;
             message.Subject = title;
 
             NetworkCredential credentials = new NetworkCredential(_sendgridUsername, _sendgridPassword);


### PR DESCRIPTION
This change allows you to now also specify text bodies, as pure HTML content increase the spam score of an email. Email templates can continue using just <body> for pure HTML message or use <html> and <text> instead. AlertSender continues sending just HTML for backwards compatibility.